### PR TITLE
문제 추가

### DIFF
--- a/[JH]11-Remove the minimum(2).js
+++ b/[JH]11-Remove the minimum(2).js
@@ -1,0 +1,9 @@
+function removeSmallest(numbers) {
+    let indexOfMin = numbers.indexOf(Math.min(...numbers));
+    return [...numbers.slice(0, indexOfMin), ...numbers.slice(indexOfMin+1)];
+}
+
+console.log(removeSmallest([1, 2, 3, 4, 5]));
+console.log(removeSmallest([5, 3, 2, 1, 4]));
+console.log(removeSmallest([2, 2, 1, 2, 1]));
+console.log(removeSmallest([]));

--- a/[JH]11-Remove the minimum.js
+++ b/[JH]11-Remove the minimum.js
@@ -1,0 +1,25 @@
+function removeSmallest(numbers) {
+    let min = 999;
+    let index = 0;
+    console.log(numbers.length);
+    for (let i = 0; i < numbers.length; i++) {
+        if (min > numbers[i]) {
+            min = numbers[i];
+            index = i;
+        }
+    }
+
+    let result = [];
+    for (let i = 0; i < numbers.length; i++) {
+        if (i != index) {
+            result.push(numbers[i]);
+        }
+    }
+
+    return result;
+}
+
+console.log(removeSmallest([1, 2, 3, 4, 5]));
+console.log(removeSmallest([5, 3, 2, 1, 4]));
+console.log(removeSmallest([2, 2, 1, 2, 1]));
+console.log(removeSmallest([]));

--- a/[JH]12-Get the Middle Character(2).js
+++ b/[JH]12-Get the Middle Character(2).js
@@ -1,0 +1,9 @@
+function getMiddle(s)
+{
+    return s.substr((Math.ceil(s.length / 2 - 1)), s.length % 2 === 0 ? 2 : 1);
+}
+
+
+console.log(getMiddle("Test"));
+console.log(getMiddle("A"));
+console.log(getMiddle("testing"));

--- a/[JH]12-Get the Middle Character.js
+++ b/[JH]12-Get the Middle Character.js
@@ -1,0 +1,14 @@
+function getMiddle(s)
+{
+    let middle = '';
+    if (s.length % 2 === 0) {
+        middle = s[Math.trunc(s.length/2-1)]+s[Math.trunc(s.length/2)];
+    } else {
+        middle = s[Math.trunc(s.length / 2)];
+    }
+    return middle;
+}
+
+console.log(getMiddle("Test"));
+console.log(getMiddle("A"));
+console.log(getMiddle("testing"));


### PR DESCRIPTION
### Math.trunc() vs parseInt()
parseInt is mainly used for a string argument. So if you're dealing with numbers, it's way better to use Math.trunc().
If you’re curious, I wrote up a performance test comparing these two functions.

### The gotcha with parseInt
There’s a potential issue when using parseInt. When you pass in an argument that's not a string, in our case a number, it will first convert the value to a string using the toString() abstract operation. Most of the time, parseInt is fine. But let's look at an example where it might not be.
~~~
const number = 1000000000000000000000.5;
const result = parseInt(number);
console.log(result); // 1 <-- 😱
~~~
☝️So why did this happen?? That’s because our argument is not a string, so the first thing parseInt does is it will convert the argument into a string.
~~~
const number = 1000000000000000000000.5;
const result = number.toString();
console.log(result); // "1e+21"
~~~
- String argument가 아닌 경우, parseInt()를 쓸 때 위와 같은 이슈가 있다. 
따라서 String argument인 경우에만 parseInt()를 쓰자.
